### PR TITLE
feat: add Catalyst Center dynamic inventory plugin

### DIFF
--- a/changelogs/fragments/inventory-plugin.yml
+++ b/changelogs/fragments/inventory-plugin.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - "Added ``cisco.catalystcenter.catalystcenter`` dynamic inventory plugin for building Ansible inventory from Catalyst Center managed devices."
+  - "Inventory plugin supports site hierarchy grouping, device role and family groups, tag-based groups, and full Constructable features (keyed_groups, compose, groups)."
+  - "Inventory plugin supports caching via the standard Ansible cache framework."
+  - "Inventory plugin auto-sets ``ansible_network_os`` and ``ansible_connection`` for IOS-XE and NX-OS devices using FQCNs."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,6 +1,2 @@
 ---
 requires_ansible: '>=2.16.0'
-plugin_routing:
-  inventory:
-    catalystcenter:
-      redirect: cisco.catalystcenter.catalystcenter

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,6 @@
 ---
 requires_ansible: '>=2.16.0'
+plugin_routing:
+  inventory:
+    catalystcenter:
+      redirect: cisco.catalystcenter.catalystcenter

--- a/plugins/inventory/catalystcenter.py
+++ b/plugins/inventory/catalystcenter.py
@@ -104,6 +104,7 @@ options:
         description:
             - Additional keyword arguments passed to the Catalyst Center C(get_device_list) API call.
             - Use this to pre-filter devices by family, role, management IP, etc.
+            - Keys C(offset) and C(limit) are reserved for pagination and will be stripped if provided.
         type: dict
         default: {}
     api_page_size:
@@ -145,11 +146,11 @@ requirements:
 """
 
 EXAMPLES = r"""
-# Minimal configuration
+# Minimal configuration (use ansible-vault for the password in production)
 plugin: cisco.catalystcenter.catalystcenter
 host: catalyst.example.com
 username: admin
-password: secret
+password: "{{ vault_cc_password }}"
 validate_certs: false
 
 # With environment variables (CATALYSTCENTER_HOST, CATALYSTCENTER_USERNAME, etc.)
@@ -215,6 +216,7 @@ try:
 except ImportError:
     HAS_CATALYSTCENTERSDK = False
 
+_PAGINATION_RESERVED_KEYS = frozenset(("offset", "limit"))
 
 _NETWORK_OS_MAP = {
     "ios": {
@@ -255,6 +257,8 @@ _SPECIAL_CHAR_MAP = {
     ord("."): "_",
 }
 
+_EXPECTED_DATA_KEYS = frozenset(("devices", "sites", "device_site_map", "tags"))
+
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     """Cisco Catalyst Center dynamic inventory plugin."""
@@ -289,6 +293,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             except KeyError:
                 cache_needs_update = True
 
+        if data is not None:
+            missing = _EXPECTED_DATA_KEYS - set(data.keys())
+            if missing:
+                self.display.warning(
+                    "Cached inventory data is missing keys {0}, refetching".format(
+                        sorted(missing)
+                    )
+                )
+                data = None
+                cache_needs_update = True
+
         if data is None:
             data = self._fetch_all_data()
 
@@ -319,7 +334,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 verify=self.get_option("validate_certs"),
                 debug=self.get_option("debug"),
             )
-        except Exception as e:
+        except (ApiError, ConnectionError, OSError) as e:
             raise AnsibleError(
                 "Failed to connect to Catalyst Center at {0}:{1}: {2}".format(
                     host, port, to_native(e)
@@ -351,32 +366,38 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         device_filters = self.get_option("device_filters")
         include_aps = self.get_option("include_aps")
 
-        try:
-            count_resp = client.devices.get_device_count()
-            device_count = count_resp.response
-        except (ApiError, Exception) as e:
-            raise AnsibleParserError(
-                "Failed to get device count: {0}".format(to_native(e))
+        safe_filters = {
+            k: v for k, v in device_filters.items()
+            if k not in _PAGINATION_RESERVED_KEYS
+        }
+        if len(safe_filters) != len(device_filters):
+            self.display.warning(
+                "device_filters contained reserved keys {0} which were "
+                "stripped to avoid breaking pagination".format(
+                    sorted(set(device_filters) & _PAGINATION_RESERVED_KEYS)
+                )
             )
 
-        pages = max(1, math.ceil(device_count / page_size))
         all_devices = []
+        offset = 1
 
-        for page in range(pages):
-            offset = page * page_size + 1
+        while True:
             try:
                 resp = client.devices.get_device_list(
                     offset=offset,
                     limit=page_size,
-                    **device_filters
+                    **safe_filters
                 )
                 page_devices = resp.response if resp.response else []
-            except (ApiError, Exception) as e:
+            except ApiError as e:
                 raise AnsibleParserError(
                     "Failed to get device list (offset={0}): {1}".format(
                         offset, to_native(e)
                     )
                 )
+
+            if not page_devices:
+                break
 
             for device in page_devices:
                 device_dict = self._device_to_dict(device)
@@ -387,6 +408,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         continue
 
                 all_devices.append(device_dict)
+
+            if len(page_devices) < page_size:
+                break
+
+            offset += page_size
 
         return all_devices
 
@@ -402,18 +428,37 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 if not k.startswith("_")
             }
         except TypeError:
-            return dict(device)
+            self.display.warning(
+                "Unexpected device object type ({0}), "
+                "attempting dict() conversion".format(type(device).__name__)
+            )
+            try:
+                return dict(device)
+            except (TypeError, ValueError) as e:
+                raise AnsibleParserError(
+                    "Cannot convert device to dict: {0}".format(to_native(e))
+                )
 
     def _fetch_site_topology(self, client):
         try:
             resp = client.topology.get_site_topology()
             sites = resp.response.sites if resp.response and resp.response.sites else []
-        except (ApiError, Exception) as e:
+        except ApiError as e:
             raise AnsibleParserError(
                 "Failed to get site topology: {0}".format(to_native(e))
             )
 
-        return [self._site_to_dict(s) for s in sites]
+        result = []
+        for s in sites:
+            site_dict = self._site_to_dict(s)
+            if not site_dict.get("id") or not site_dict.get("name"):
+                self.display.warning(
+                    "Skipping site with missing id or name: {0}".format(site_dict)
+                )
+                continue
+            result.append(site_dict)
+
+        return result
 
     def _site_to_dict(self, site):
         if hasattr(site, "to_dict"):
@@ -434,7 +479,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         try:
             resp = client.topology.get_physical_topology()
             nodes = resp.response.nodes if resp.response and resp.response.nodes else []
-        except (ApiError, Exception) as e:
+        except ApiError as e:
             raise AnsibleParserError(
                 "Failed to get physical topology: {0}".format(to_native(e))
             )
@@ -463,11 +508,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not device_ids:
             return tags
 
+        device_id_set = set(device_ids)
+
         try:
             resp = client.tag.get_tag()
             all_tags = resp.response if resp.response else []
-        except (ApiError, Exception):
-            self.display.warning("Failed to fetch tags, skipping tag-based grouping")
+        except ApiError as e:
+            self.display.warning(
+                "Failed to fetch tags from Catalyst Center, "
+                "skipping tag-based grouping: {0}".format(to_native(e))
+            )
             return tags
 
         for tag_obj in all_tags:
@@ -485,7 +535,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     id=tag_id, member_type="networkdevice"
                 )
                 members = members_resp.response if members_resp.response else []
-            except (ApiError, Exception):
+            except ApiError as e:
+                self.display.warning(
+                    "Failed to fetch members for tag '{0}' (id={1}), "
+                    "this tag will be missing from inventory: {2}".format(
+                        tag_name, tag_id, to_native(e)
+                    )
+                )
                 continue
 
             for member in members:
@@ -493,7 +549,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     member.to_dict() if hasattr(member, "to_dict") else vars(member)
                 )
                 member_id = member_dict.get("instanceUuid", "")
-                if member_id in device_ids:
+                if member_id in device_id_set:
                     tags.setdefault(member_id, []).append(tag_name)
 
         return tags
@@ -505,6 +561,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         tags = data.get("tags", {})
 
         strict = self.get_option("strict")
+        skipped_count = 0
 
         if self.get_option("group_by_site"):
             self._build_site_groups(sites)
@@ -512,6 +569,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for device in devices:
             hostname = self._get_hostname(device)
             if not hostname:
+                skipped_count += 1
                 continue
 
             self.inventory.add_host(hostname)
@@ -569,6 +627,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             )
             self._add_host_to_keyed_groups(
                 self.get_option("keyed_groups"), host_vars, hostname, strict=strict
+            )
+
+        if skipped_count:
+            self.display.warning(
+                "Skipped {0} device(s) with no usable hostname. "
+                "Consider using hostname_source: managementIpAddress "
+                "or hostname_source: id".format(skipped_count)
             )
 
     def _get_hostname(self, device):
@@ -631,8 +696,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 if parent_group and parent_group != child_group:
                     try:
                         self.inventory.add_child(parent_group, child_group)
-                    except Exception:
-                        pass
+                    except AnsibleError as e:
+                        self.display.warning(
+                            "Could not nest site group '{0}' under '{1}': "
+                            "{2}".format(child_group, parent_group, to_native(e))
+                        )
 
     def _normalize_site_name(self, site):
         name = site.get("name", "unknown")

--- a/plugins/inventory/catalystcenter.py
+++ b/plugins/inventory/catalystcenter.py
@@ -1,0 +1,653 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+name: catalystcenter
+plugin_type: inventory
+short_description: Cisco Catalyst Center dynamic inventory plugin
+description:
+    - Queries Cisco Catalyst Center for network devices and builds an Ansible inventory.
+    - Creates groups based on site hierarchy, device role, device family, and tags.
+    - Supports pagination for large-scale deployments (500+ devices).
+    - Uses the catalystcentersdk Python SDK for API communication.
+version_added: "2.10.0"
+extends_documentation_fragment:
+    - constructed
+    - inventory_cache
+options:
+    plugin:
+        description: Token that ensures this is a source file for the plugin.
+        required: true
+        choices: ["cisco.catalystcenter.catalystcenter"]
+        type: str
+    host:
+        description:
+            - Hostname or IP address of the Catalyst Center appliance.
+        required: true
+        type: str
+        env:
+            - name: CATALYSTCENTER_HOST
+    port:
+        description:
+            - TCP port for the Catalyst Center API.
+        type: int
+        default: 443
+        env:
+            - name: CATALYSTCENTER_PORT
+    username:
+        description:
+            - Username for Catalyst Center authentication.
+        type: str
+        default: admin
+        env:
+            - name: CATALYSTCENTER_USERNAME
+    password:
+        description:
+            - Password for Catalyst Center authentication.
+        type: str
+        required: true
+        env:
+            - name: CATALYSTCENTER_PASSWORD
+    validate_certs:
+        description:
+            - Whether to validate SSL certificates.
+        type: bool
+        default: true
+        env:
+            - name: CATALYSTCENTER_VERIFY
+    api_version:
+        description:
+            - Catalyst Center API version string.
+        type: str
+        default: "3.1.6.0"
+        env:
+            - name: CATALYSTCENTER_VERSION
+    debug:
+        description:
+            - Enable SDK debug logging.
+        type: bool
+        default: false
+        env:
+            - name: CATALYSTCENTER_DEBUG
+    use_mgmt_ip:
+        description:
+            - Set C(ansible_host) to the device management IP address.
+        type: bool
+        default: true
+    hostname_source:
+        description:
+            - Device attribute to use as the Ansible inventory hostname.
+        type: str
+        default: hostname
+        choices:
+            - hostname
+            - managementIpAddress
+            - id
+    include_aps:
+        description:
+            - Include Unified Access Points in the inventory.
+            - Disabled by default because APs are not typically managed via CLI.
+        type: bool
+        default: false
+    set_network_os:
+        description:
+            - Automatically set C(ansible_network_os) and C(ansible_connection) based on the device software type.
+        type: bool
+        default: true
+    device_filters:
+        description:
+            - Additional keyword arguments passed to the Catalyst Center C(get_device_list) API call.
+            - Use this to pre-filter devices by family, role, management IP, etc.
+        type: dict
+        default: {}
+    api_page_size:
+        description:
+            - Number of devices to retrieve per API call.
+            - Catalyst Center has a maximum of 500 records per call.
+        type: int
+        default: 500
+    group_by_site:
+        description:
+            - Create Ansible groups from the Catalyst Center site hierarchy.
+        type: bool
+        default: true
+    group_by_role:
+        description:
+            - Create Ansible groups by device role (e.g., C(role_ACCESS), C(role_CORE)).
+        type: bool
+        default: true
+    group_by_family:
+        description:
+            - Create Ansible groups by device family (e.g., C(family_Switches_and_Hubs)).
+        type: bool
+        default: true
+    group_by_tag:
+        description:
+            - Create Ansible groups from Catalyst Center device tags.
+            - Disabled by default because it requires additional API calls.
+        type: bool
+        default: false
+    tag_prefix:
+        description:
+            - Prefix for tag-based group names.
+        type: str
+        default: "tag_"
+author:
+    - Steve Fulmer (@stevefulme1)
+requirements:
+    - catalystcentersdk >= 2.3.7
+"""
+
+EXAMPLES = r"""
+# Minimal configuration
+plugin: cisco.catalystcenter.catalystcenter
+host: catalyst.example.com
+username: admin
+password: secret
+validate_certs: false
+
+# With environment variables (CATALYSTCENTER_HOST, CATALYSTCENTER_USERNAME, etc.)
+plugin: cisco.catalystcenter.catalystcenter
+validate_certs: false
+
+# Full-featured configuration
+plugin: cisco.catalystcenter.catalystcenter
+host: catalyst.example.com
+username: admin
+password: "{{ vault_cc_password }}"
+validate_certs: false
+api_version: "3.1.6.0"
+
+# Grouping options
+group_by_site: true
+group_by_role: true
+group_by_family: true
+group_by_tag: true
+tag_prefix: "cctag_"
+
+# Include access points
+include_aps: true
+
+# Pre-filter devices by family
+device_filters:
+  family: "Switches and Hubs"
+
+# Constructable features
+keyed_groups:
+  - key: cc_software_type
+    prefix: os
+    separator: "_"
+  - key: cc_series
+    prefix: hw
+    separator: "_"
+compose:
+  ansible_host: cc_management_ip
+  site_role: cc_role | lower
+groups:
+  reachable: cc_reachability_status == "Reachable"
+  unreachable: cc_reachability_status == "Unreachable"
+
+# Caching (reduces API calls)
+cache: true
+cache_plugin: ansible.builtin.jsonfile
+cache_timeout: 3600
+cache_connection: /tmp/catalystcenter_inventory_cache
+"""
+
+import math
+import re
+
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.module_utils._text import to_native
+from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, Constructable
+
+try:
+    from catalystcentersdk import CatalystCenterAPI
+    from catalystcentersdk.exceptions import ApiError
+
+    HAS_CATALYSTCENTERSDK = True
+except ImportError:
+    HAS_CATALYSTCENTERSDK = False
+
+
+_NETWORK_OS_MAP = {
+    "ios": {
+        "ansible_network_os": "cisco.ios.ios",
+        "ansible_connection": "ansible.netcommon.network_cli",
+        "ansible_become": True,
+        "ansible_become_method": "enable",
+    },
+    "ios-xe": {
+        "ansible_network_os": "cisco.ios.ios",
+        "ansible_connection": "ansible.netcommon.network_cli",
+        "ansible_become": True,
+        "ansible_become_method": "enable",
+    },
+    "nx-os": {
+        "ansible_network_os": "cisco.nxos.nxos",
+        "ansible_connection": "ansible.netcommon.network_cli",
+        "ansible_become": True,
+        "ansible_become_method": "enable",
+    },
+    "nxos": {
+        "ansible_network_os": "cisco.nxos.nxos",
+        "ansible_connection": "ansible.netcommon.network_cli",
+        "ansible_become": True,
+        "ansible_become_method": "enable",
+    },
+}
+
+_SPECIAL_CHAR_MAP = {
+    ord("ä"): "ae",
+    ord("ü"): "ue",
+    ord("ö"): "oe",
+    ord("ß"): "ss",
+    ord("("): "_",
+    ord(")"): "_",
+    ord(" "): "_",
+    ord("-"): "_",
+    ord("."): "_",
+}
+
+
+class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
+    """Cisco Catalyst Center dynamic inventory plugin."""
+
+    NAME = "cisco.catalystcenter.catalystcenter"
+
+    def __init__(self):
+        super().__init__()
+        self._client = None
+        self._site_id_to_group = {}
+
+    def verify_file(self, path):
+        if super().verify_file(path):
+            if path.endswith((".catalystcenter.yml", ".catalystcenter.yaml")):
+                return True
+        return False
+
+    def parse(self, inventory, loader, path, cache=True):
+        super().parse(inventory, loader, path, cache=cache)
+        self._read_config_data(path)
+
+        cache_key = self.get_cache_key(path)
+        user_cache_setting = self.get_option("cache")
+        attempt_to_read_cache = user_cache_setting and cache
+        cache_needs_update = user_cache_setting and not cache
+
+        data = None
+
+        if attempt_to_read_cache:
+            try:
+                data = self._cache[cache_key]
+            except KeyError:
+                cache_needs_update = True
+
+        if data is None:
+            data = self._fetch_all_data()
+
+        if cache_needs_update:
+            self._cache[cache_key] = data
+
+        self._populate(data)
+
+    def _get_client(self):
+        if not HAS_CATALYSTCENTERSDK:
+            raise AnsibleError(
+                "The catalystcentersdk Python package is required. "
+                "Install it with: pip install catalystcentersdk"
+            )
+
+        if self._client is not None:
+            return self._client
+
+        host = self.get_option("host")
+        port = self.get_option("port")
+
+        try:
+            self._client = CatalystCenterAPI(
+                username=self.get_option("username"),
+                password=self.get_option("password"),
+                base_url="https://{0}:{1}".format(host, port),
+                version=self.get_option("api_version"),
+                verify=self.get_option("validate_certs"),
+                debug=self.get_option("debug"),
+            )
+        except Exception as e:
+            raise AnsibleError(
+                "Failed to connect to Catalyst Center at {0}:{1}: {2}".format(
+                    host, port, to_native(e)
+                )
+            )
+
+        return self._client
+
+    def _fetch_all_data(self):
+        client = self._get_client()
+
+        devices = self._fetch_devices(client)
+        sites = self._fetch_site_topology(client)
+        device_site_map = self._fetch_device_site_map(client)
+
+        tags = {}
+        if self.get_option("group_by_tag"):
+            tags = self._fetch_device_tags(client, [d["id"] for d in devices])
+
+        return {
+            "devices": devices,
+            "sites": sites,
+            "device_site_map": device_site_map,
+            "tags": tags,
+        }
+
+    def _fetch_devices(self, client):
+        page_size = self.get_option("api_page_size")
+        device_filters = self.get_option("device_filters")
+        include_aps = self.get_option("include_aps")
+
+        try:
+            count_resp = client.devices.get_device_count()
+            device_count = count_resp.response
+        except (ApiError, Exception) as e:
+            raise AnsibleParserError(
+                "Failed to get device count: {0}".format(to_native(e))
+            )
+
+        pages = max(1, math.ceil(device_count / page_size))
+        all_devices = []
+
+        for page in range(pages):
+            offset = page * page_size + 1
+            try:
+                resp = client.devices.get_device_list(
+                    offset=offset,
+                    limit=page_size,
+                    **device_filters
+                )
+                page_devices = resp.response if resp.response else []
+            except (ApiError, Exception) as e:
+                raise AnsibleParserError(
+                    "Failed to get device list (offset={0}): {1}".format(
+                        offset, to_native(e)
+                    )
+                )
+
+            for device in page_devices:
+                device_dict = self._device_to_dict(device)
+
+                if not include_aps:
+                    family = device_dict.get("family", "")
+                    if family and "Unified AP" in family:
+                        continue
+
+                all_devices.append(device_dict)
+
+        return all_devices
+
+    def _device_to_dict(self, device):
+        if hasattr(device, "to_dict"):
+            return device.to_dict()
+        if isinstance(device, dict):
+            return device
+        try:
+            return {
+                k: v
+                for k, v in vars(device).items()
+                if not k.startswith("_")
+            }
+        except TypeError:
+            return dict(device)
+
+    def _fetch_site_topology(self, client):
+        try:
+            resp = client.topology.get_site_topology()
+            sites = resp.response.sites if resp.response and resp.response.sites else []
+        except (ApiError, Exception) as e:
+            raise AnsibleParserError(
+                "Failed to get site topology: {0}".format(to_native(e))
+            )
+
+        return [self._site_to_dict(s) for s in sites]
+
+    def _site_to_dict(self, site):
+        if hasattr(site, "to_dict"):
+            d = site.to_dict()
+        elif isinstance(site, dict):
+            d = site
+        else:
+            d = {k: v for k, v in vars(site).items() if not k.startswith("_")}
+
+        return {
+            "name": d.get("name", ""),
+            "id": d.get("id", ""),
+            "parentId": d.get("parentId", ""),
+            "locationType": d.get("locationType", ""),
+        }
+
+    def _fetch_device_site_map(self, client):
+        try:
+            resp = client.topology.get_physical_topology()
+            nodes = resp.response.nodes if resp.response and resp.response.nodes else []
+        except (ApiError, Exception) as e:
+            raise AnsibleParserError(
+                "Failed to get physical topology: {0}".format(to_native(e))
+            )
+
+        device_site_map = {}
+        for node in nodes:
+            node_dict = node if isinstance(node, dict) else (
+                node.to_dict() if hasattr(node, "to_dict") else vars(node)
+            )
+            node_id = node_dict.get("id", "")
+            additional_info = node_dict.get("additionalInfo", {})
+            if isinstance(additional_info, dict):
+                site_id = additional_info.get("siteid", "")
+            elif hasattr(additional_info, "get"):
+                site_id = additional_info.get("siteid", "")
+            else:
+                site_id = ""
+
+            if node_id and site_id:
+                device_site_map[node_id] = site_id
+
+        return device_site_map
+
+    def _fetch_device_tags(self, client, device_ids):
+        tags = {}
+        if not device_ids:
+            return tags
+
+        try:
+            resp = client.tag.get_tag()
+            all_tags = resp.response if resp.response else []
+        except (ApiError, Exception):
+            self.display.warning("Failed to fetch tags, skipping tag-based grouping")
+            return tags
+
+        for tag_obj in all_tags:
+            tag_dict = tag_obj if isinstance(tag_obj, dict) else (
+                tag_obj.to_dict() if hasattr(tag_obj, "to_dict") else vars(tag_obj)
+            )
+            tag_name = tag_dict.get("name", "")
+            tag_id = tag_dict.get("id", "")
+
+            if not tag_name or not tag_id:
+                continue
+
+            try:
+                members_resp = client.tag.get_tag_members_by_id(
+                    id=tag_id, member_type="networkdevice"
+                )
+                members = members_resp.response if members_resp.response else []
+            except (ApiError, Exception):
+                continue
+
+            for member in members:
+                member_dict = member if isinstance(member, dict) else (
+                    member.to_dict() if hasattr(member, "to_dict") else vars(member)
+                )
+                member_id = member_dict.get("instanceUuid", "")
+                if member_id in device_ids:
+                    tags.setdefault(member_id, []).append(tag_name)
+
+        return tags
+
+    def _populate(self, data):
+        devices = data.get("devices", [])
+        sites = data.get("sites", [])
+        device_site_map = data.get("device_site_map", {})
+        tags = data.get("tags", {})
+
+        strict = self.get_option("strict")
+
+        if self.get_option("group_by_site"):
+            self._build_site_groups(sites)
+
+        for device in devices:
+            hostname = self._get_hostname(device)
+            if not hostname:
+                continue
+
+            self.inventory.add_host(hostname)
+
+            host_vars = self._build_host_vars(device)
+            for var_name, var_value in host_vars.items():
+                self.inventory.set_variable(hostname, var_name, var_value)
+
+            if self.get_option("use_mgmt_ip"):
+                mgmt_ip = device.get("managementIpAddress", "")
+                if mgmt_ip:
+                    self.inventory.set_variable(hostname, "ansible_host", mgmt_ip)
+
+            if self.get_option("set_network_os"):
+                self._set_network_os(hostname, device)
+
+            if self.get_option("group_by_site"):
+                device_id = device.get("id", "")
+                site_id = device_site_map.get(device_id, "")
+                site_group = self._site_id_to_group.get(site_id)
+                if site_group:
+                    self.inventory.add_child(site_group, hostname)
+
+            if self.get_option("group_by_role"):
+                role = device.get("role", "")
+                if role and role != "UNKNOWN":
+                    role_group = self._sanitize_group_name("role_{0}".format(role))
+                    self.inventory.add_group(role_group)
+                    self.inventory.add_child(role_group, hostname)
+
+            if self.get_option("group_by_family"):
+                family = device.get("family", "")
+                if family:
+                    family_group = self._sanitize_group_name(
+                        "family_{0}".format(family)
+                    )
+                    self.inventory.add_group(family_group)
+                    self.inventory.add_child(family_group, hostname)
+
+            if self.get_option("group_by_tag"):
+                device_id = device.get("id", "")
+                prefix = self.get_option("tag_prefix")
+                for tag_name in tags.get(device_id, []):
+                    tag_group = self._sanitize_group_name(
+                        "{0}{1}".format(prefix, tag_name)
+                    )
+                    self.inventory.add_group(tag_group)
+                    self.inventory.add_child(tag_group, hostname)
+
+            self._set_composite_vars(
+                self.get_option("compose"), host_vars, hostname, strict=strict
+            )
+            self._add_host_to_composed_groups(
+                self.get_option("groups"), host_vars, hostname, strict=strict
+            )
+            self._add_host_to_keyed_groups(
+                self.get_option("keyed_groups"), host_vars, hostname, strict=strict
+            )
+
+    def _get_hostname(self, device):
+        source = self.get_option("hostname_source")
+        hostname = device.get(source, "")
+        if not hostname:
+            hostname = device.get("hostname", device.get("managementIpAddress", ""))
+        return hostname
+
+    def _build_host_vars(self, device):
+        serial = device.get("serialNumber", "")
+        if isinstance(serial, str) and ", " in serial:
+            serial = serial.split(", ")
+
+        return {
+            "cc_id": device.get("id", ""),
+            "cc_hostname": device.get("hostname", ""),
+            "cc_management_ip": device.get("managementIpAddress", ""),
+            "cc_platform_id": device.get("platformId", ""),
+            "cc_software_type": device.get("softwareType", ""),
+            "cc_software_version": device.get("softwareVersion", ""),
+            "cc_serial_number": serial,
+            "cc_mac_address": device.get("macAddress", ""),
+            "cc_role": device.get("role", ""),
+            "cc_family": device.get("family", ""),
+            "cc_type": device.get("type", ""),
+            "cc_series": device.get("series", ""),
+            "cc_reachability_status": device.get("reachabilityStatus", ""),
+            "cc_collection_status": device.get("collectionStatus", ""),
+            "cc_up_time": device.get("upTime", ""),
+            "cc_last_updated": device.get("lastUpdated", ""),
+            "cc_location": device.get("location", ""),
+            "cc_associated_wlc_ip": device.get("associatedWlcIp", ""),
+        }
+
+    def _set_network_os(self, hostname, device):
+        software_type = device.get("softwareType", "")
+        if not software_type:
+            return
+
+        os_vars = _NETWORK_OS_MAP.get(software_type.lower())
+        if os_vars:
+            for var_name, var_value in os_vars.items():
+                self.inventory.set_variable(hostname, var_name, var_value)
+
+    def _build_site_groups(self, sites):
+        site_ids = {s["id"] for s in sites}
+        self._site_id_to_group = {}
+
+        for site in sites:
+            group_name = self._normalize_site_name(site)
+            self.inventory.add_group(group_name)
+            self._site_id_to_group[site["id"]] = group_name
+
+        for site in sites:
+            parent_id = site.get("parentId", "")
+            child_group = self._site_id_to_group.get(site["id"])
+            if parent_id in site_ids and child_group:
+                parent_group = self._site_id_to_group.get(parent_id)
+                if parent_group and parent_group != child_group:
+                    try:
+                        self.inventory.add_child(parent_group, child_group)
+                    except Exception:
+                        pass
+
+    def _normalize_site_name(self, site):
+        name = site.get("name", "unknown")
+        normalized = name.translate(_SPECIAL_CHAR_MAP).lower()
+        normalized = re.sub(r"_+", "_", normalized).strip("_")
+
+        if site.get("locationType") == "building":
+            normalized = "bld_{0}".format(normalized)
+
+        return self._sanitize_group_name(normalized)
+
+    @staticmethod
+    def _sanitize_group_name(name):
+        name = re.sub(r"[^A-Za-z0-9_]", "_", name)
+        name = re.sub(r"_+", "_", name).strip("_")
+        if name and name[0].isdigit():
+            name = "_{0}".format(name)
+        return name

--- a/tests/integration/targets/catalystcenter_inventory/inventory.catalystcenter.yml
+++ b/tests/integration/targets/catalystcenter_inventory/inventory.catalystcenter.yml
@@ -1,0 +1,6 @@
+---
+plugin: cisco.catalystcenter.catalystcenter
+validate_certs: false
+group_by_site: true
+group_by_role: true
+group_by_family: true

--- a/tests/integration/targets/catalystcenter_inventory/tasks/main.yml
+++ b/tests/integration/targets/catalystcenter_inventory/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Test Catalyst Center inventory plugin loads
+  block:
+    - name: Verify plugin is discoverable
+      ansible.builtin.command:
+        cmd: ansible-doc -t inventory cisco.catalystcenter.catalystcenter
+      register: plugin_doc
+      changed_when: false
+
+    - name: Assert plugin documentation is available
+      ansible.builtin.assert:
+        that:
+          - plugin_doc.rc == 0
+          - "'Cisco Catalyst Center dynamic inventory plugin' in plugin_doc.stdout"
+        fail_msg: "Plugin documentation not found or incorrect"
+
+    - name: Verify inventory file is recognized
+      ansible.builtin.command:
+        cmd: ansible-inventory -i {{ role_path }}/inventory.catalystcenter.yml --list
+      register: inventory_result
+      changed_when: false
+      ignore_errors: true
+      environment:
+        CATALYSTCENTER_HOST: "{{ catalystcenter_host | default('sandbox.example.com') }}"
+        CATALYSTCENTER_USERNAME: "{{ catalystcenter_username | default('admin') }}"
+        CATALYSTCENTER_PASSWORD: "{{ catalystcenter_password | default('changeme') }}"
+        CATALYSTCENTER_VERIFY: "false"
+
+    - name: Assert inventory command ran (connection errors are acceptable in CI)
+      ansible.builtin.assert:
+        that:
+          - inventory_result is defined
+        fail_msg: "Inventory plugin failed to execute"
+...

--- a/tests/unit/plugins/inventory/test_catalystcenter.py
+++ b/tests/unit/plugins/inventory/test_catalystcenter.py
@@ -1,0 +1,592 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import os
+import pytest
+
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from ansible.inventory.data import InventoryData
+from ansible.parsing.dataloader import DataLoader
+
+from ansible_collections.cisco.catalystcenter.plugins.inventory.catalystcenter import (
+    InventoryModule,
+    _NETWORK_OS_MAP,
+    _SPECIAL_CHAR_MAP,
+)
+
+
+@pytest.fixture
+def inventory_plugin():
+    plugin = InventoryModule()
+    plugin.inventory = InventoryData()
+    plugin.loader = DataLoader()
+    plugin.display = MagicMock()
+    plugin._options = {}
+    return plugin
+
+
+def _set_options(plugin, **kwargs):
+    defaults = {
+        "host": "catalyst.example.com",
+        "port": 443,
+        "username": "admin",
+        "password": "secret",
+        "validate_certs": False,
+        "api_version": "3.1.6.0",
+        "debug": False,
+        "use_mgmt_ip": True,
+        "hostname_source": "hostname",
+        "include_aps": False,
+        "set_network_os": True,
+        "device_filters": {},
+        "api_page_size": 500,
+        "group_by_site": True,
+        "group_by_role": True,
+        "group_by_family": True,
+        "group_by_tag": False,
+        "tag_prefix": "tag_",
+        "cache": False,
+        "strict": False,
+        "compose": {},
+        "groups": {},
+        "keyed_groups": [],
+    }
+    defaults.update(kwargs)
+    plugin._options = defaults
+    plugin.get_option = lambda key: plugin._options.get(key)
+
+
+def _make_device(**overrides):
+    device = {
+        "id": "dev-001",
+        "hostname": "switch-01",
+        "managementIpAddress": "10.0.0.1",
+        "platformId": "C9300-48P",
+        "softwareType": "IOS-XE",
+        "softwareVersion": "17.9.1",
+        "serialNumber": "FDO12345ABC",
+        "macAddress": "aa:bb:cc:dd:ee:ff",
+        "role": "ACCESS",
+        "family": "Switches and Hubs",
+        "type": "Cisco Catalyst 9300",
+        "series": "Cisco Catalyst 9300 Series",
+        "reachabilityStatus": "Reachable",
+        "collectionStatus": "Managed",
+        "upTime": "10 days, 2:30:00",
+        "lastUpdated": "2026-05-29T00:00:00.000Z",
+        "location": None,
+        "associatedWlcIp": None,
+    }
+    device.update(overrides)
+    return device
+
+
+def _make_site(name, site_id, parent_id, location_type="area"):
+    return {
+        "name": name,
+        "id": site_id,
+        "parentId": parent_id,
+        "locationType": location_type,
+    }
+
+
+# ---------------------------------------------------------------------------
+# verify_file tests
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyFile:
+    def test_valid_extensions(self, inventory_plugin, tmp_path):
+        for ext in (".catalystcenter.yml", ".catalystcenter.yaml"):
+            f = tmp_path / ("inv" + ext)
+            f.write_text("plugin: cisco.catalystcenter.catalystcenter\n")
+            assert inventory_plugin.verify_file(str(f)) is True
+
+    def test_invalid_extensions(self, inventory_plugin, tmp_path):
+        for ext in (".yml", ".yaml", ".now.yml", ".catalystcenter.json"):
+            f = tmp_path / ("inv" + ext)
+            f.write_text("plugin: cisco.catalystcenter.catalystcenter\n")
+            assert inventory_plugin.verify_file(str(f)) is False
+
+
+# ---------------------------------------------------------------------------
+# Client creation tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetClient:
+    @patch(
+        "ansible_collections.cisco.catalystcenter.plugins.inventory.catalystcenter.CatalystCenterAPI"
+    )
+    def test_success(self, mock_sdk, inventory_plugin):
+        _set_options(inventory_plugin)
+        client = inventory_plugin._get_client()
+        mock_sdk.assert_called_once_with(
+            username="admin",
+            password="secret",
+            base_url="https://catalyst.example.com:443",
+            version="3.1.6.0",
+            verify=False,
+            debug=False,
+        )
+        assert client is not None
+
+    @patch(
+        "ansible_collections.cisco.catalystcenter.plugins.inventory.catalystcenter.HAS_CATALYSTCENTERSDK",
+        False,
+    )
+    def test_missing_sdk(self, inventory_plugin):
+        _set_options(inventory_plugin)
+        with pytest.raises(Exception, match="catalystcentersdk"):
+            inventory_plugin._get_client()
+
+
+# ---------------------------------------------------------------------------
+# Device fetching tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchDevices:
+    def _mock_client(self, device_count, devices_per_page):
+        client = MagicMock()
+        count_resp = MagicMock()
+        count_resp.response = device_count
+        client.devices.get_device_count.return_value = count_resp
+
+        pages = []
+        remaining = device_count
+        page_num = 0
+        while remaining > 0:
+            batch_size = min(remaining, devices_per_page)
+            page_devices = [
+                _make_device(
+                    id="dev-{0}".format(page_num * devices_per_page + i),
+                    hostname="switch-{0}".format(page_num * devices_per_page + i),
+                )
+                for i in range(batch_size)
+            ]
+            resp = MagicMock()
+            resp.response = page_devices
+            pages.append(resp)
+            remaining -= batch_size
+            page_num += 1
+
+        client.devices.get_device_list.side_effect = pages
+        return client
+
+    def test_single_page(self, inventory_plugin):
+        _set_options(inventory_plugin, api_page_size=500)
+        client = self._mock_client(100, 500)
+        devices = inventory_plugin._fetch_devices(client)
+        assert len(devices) == 100
+        assert client.devices.get_device_list.call_count == 1
+
+    def test_pagination(self, inventory_plugin):
+        _set_options(inventory_plugin, api_page_size=500)
+        client = self._mock_client(1200, 500)
+        devices = inventory_plugin._fetch_devices(client)
+        assert len(devices) == 1200
+        assert client.devices.get_device_list.call_count == 3
+
+        calls = client.devices.get_device_list.call_args_list
+        assert calls[0].kwargs["offset"] == 1
+        assert calls[1].kwargs["offset"] == 501
+        assert calls[2].kwargs["offset"] == 1001
+
+    def test_ap_filtering(self, inventory_plugin):
+        _set_options(inventory_plugin, include_aps=False)
+        client = MagicMock()
+        count_resp = MagicMock()
+        count_resp.response = 3
+        client.devices.get_device_count.return_value = count_resp
+
+        resp = MagicMock()
+        resp.response = [
+            _make_device(id="dev-1", hostname="switch-1", family="Switches and Hubs"),
+            _make_device(id="dev-2", hostname="ap-1", family="Unified AP"),
+            _make_device(id="dev-3", hostname="switch-2", family="Switches and Hubs"),
+        ]
+        client.devices.get_device_list.return_value = resp
+
+        devices = inventory_plugin._fetch_devices(client)
+        assert len(devices) == 2
+        assert all(d["family"] != "Unified AP" for d in devices)
+
+    def test_ap_included(self, inventory_plugin):
+        _set_options(inventory_plugin, include_aps=True)
+        client = MagicMock()
+        count_resp = MagicMock()
+        count_resp.response = 2
+        client.devices.get_device_count.return_value = count_resp
+
+        resp = MagicMock()
+        resp.response = [
+            _make_device(id="dev-1", hostname="switch-1", family="Switches and Hubs"),
+            _make_device(id="dev-2", hostname="ap-1", family="Unified AP"),
+        ]
+        client.devices.get_device_list.return_value = resp
+
+        devices = inventory_plugin._fetch_devices(client)
+        assert len(devices) == 2
+
+
+# ---------------------------------------------------------------------------
+# Site topology tests
+# ---------------------------------------------------------------------------
+
+
+class TestSiteTopology:
+    def test_hierarchy(self, inventory_plugin):
+        _set_options(inventory_plugin)
+        sites = [
+            _make_site("Global", "site-1", "", "area"),
+            _make_site("US", "site-2", "site-1", "area"),
+            _make_site("NYC Office", "site-3", "site-2", "building"),
+        ]
+
+        inventory_plugin._build_site_groups(sites)
+        groups = inventory_plugin.inventory.groups
+
+        assert "global" in groups
+        assert "us" in groups
+        assert "bld_nyc_office" in groups
+
+        us_children = [g.name for g in groups["us"].child_groups]
+        assert "bld_nyc_office" in us_children
+
+    def test_special_char_normalization(self, inventory_plugin):
+        site = _make_site("München (HQ)", "s1", "", "area")
+        name = inventory_plugin._normalize_site_name(site)
+        assert "(" not in name
+        assert ")" not in name
+        assert " " not in name
+        assert "ü" not in name
+        assert "muenchen" in name
+
+    def test_building_prefix(self, inventory_plugin):
+        site = _make_site("Main Campus", "s1", "", "building")
+        name = inventory_plugin._normalize_site_name(site)
+        assert name.startswith("bld_")
+
+
+# ---------------------------------------------------------------------------
+# Host variable tests
+# ---------------------------------------------------------------------------
+
+
+class TestHostVars:
+    def test_all_fields(self, inventory_plugin):
+        device = _make_device()
+        host_vars = inventory_plugin._build_host_vars(device)
+        assert host_vars["cc_id"] == "dev-001"
+        assert host_vars["cc_hostname"] == "switch-01"
+        assert host_vars["cc_management_ip"] == "10.0.0.1"
+        assert host_vars["cc_software_type"] == "IOS-XE"
+        assert host_vars["cc_role"] == "ACCESS"
+        assert host_vars["cc_family"] == "Switches and Hubs"
+
+    def test_ansible_host_mgmt_ip(self, inventory_plugin):
+        _set_options(inventory_plugin, use_mgmt_ip=True)
+        device = _make_device()
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        host_vars = inventory_plugin.inventory.get_host("switch-01").vars
+        assert host_vars["ansible_host"] == "10.0.0.1"
+
+    def test_ansible_host_disabled(self, inventory_plugin):
+        _set_options(inventory_plugin, use_mgmt_ip=False)
+        device = _make_device()
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        host_vars = inventory_plugin.inventory.get_host("switch-01").vars
+        assert "ansible_host" not in host_vars
+
+    def test_serial_number_split(self, inventory_plugin):
+        device = _make_device(serialNumber="SN1, SN2, SN3")
+        host_vars = inventory_plugin._build_host_vars(device)
+        assert host_vars["cc_serial_number"] == ["SN1", "SN2", "SN3"]
+
+
+# ---------------------------------------------------------------------------
+# Network OS mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestNetworkOS:
+    def test_ios_xe(self, inventory_plugin):
+        _set_options(inventory_plugin)
+        device = _make_device(softwareType="IOS-XE")
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        host_vars = inventory_plugin.inventory.get_host("switch-01").vars
+        assert host_vars["ansible_network_os"] == "cisco.ios.ios"
+        assert host_vars["ansible_connection"] == "ansible.netcommon.network_cli"
+        assert host_vars["ansible_become"] is True
+        assert host_vars["ansible_become_method"] == "enable"
+
+    def test_nxos(self, inventory_plugin):
+        _set_options(inventory_plugin)
+        device = _make_device(
+            softwareType="NX-OS", hostname="nexus-01", family="Switches and Hubs"
+        )
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        host_vars = inventory_plugin.inventory.get_host("nexus-01").vars
+        assert host_vars["ansible_network_os"] == "cisco.nxos.nxos"
+
+    def test_disabled(self, inventory_plugin):
+        _set_options(inventory_plugin, set_network_os=False)
+        device = _make_device(softwareType="IOS-XE")
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        host_vars = inventory_plugin.inventory.get_host("switch-01").vars
+        assert "ansible_network_os" not in host_vars
+
+
+# ---------------------------------------------------------------------------
+# Grouping tests
+# ---------------------------------------------------------------------------
+
+
+class TestGrouping:
+    def test_site_mapping(self, inventory_plugin):
+        _set_options(inventory_plugin)
+        sites = [_make_site("Global", "site-1", "", "area")]
+        device = _make_device(id="dev-001")
+        data = {
+            "devices": [device],
+            "sites": sites,
+            "device_site_map": {"dev-001": "site-1"},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        host = inventory_plugin.inventory.get_host("switch-01")
+        group_names = [g.name for g in inventory_plugin.inventory.groups.values() if host in g.hosts]
+        assert "global" in group_names
+
+    def test_role_group(self, inventory_plugin):
+        _set_options(inventory_plugin)
+        device = _make_device(role="ACCESS")
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        assert "role_ACCESS" in inventory_plugin.inventory.groups
+
+    def test_family_group(self, inventory_plugin):
+        _set_options(inventory_plugin)
+        device = _make_device(family="Switches and Hubs")
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        assert "family_Switches_and_Hubs" in inventory_plugin.inventory.groups
+
+    def test_tag_group(self, inventory_plugin):
+        _set_options(inventory_plugin, group_by_tag=True, tag_prefix="tag_")
+        device = _make_device(id="dev-001")
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {"dev-001": ["production", "critical"]},
+        }
+        inventory_plugin._populate(data)
+        assert "tag_production" in inventory_plugin.inventory.groups
+        assert "tag_critical" in inventory_plugin.inventory.groups
+
+    def test_role_group_disabled(self, inventory_plugin):
+        _set_options(inventory_plugin, group_by_role=False)
+        device = _make_device(role="ACCESS")
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        assert "role_ACCESS" not in inventory_plugin.inventory.groups
+
+
+# ---------------------------------------------------------------------------
+# Caching tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaching:
+    def test_cache_write(self, inventory_plugin):
+        _set_options(inventory_plugin, cache=True)
+        inventory_plugin._cache = {}
+
+        data = {
+            "devices": [_make_device()],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+
+        with patch.object(inventory_plugin, "_fetch_all_data", return_value=data):
+            with patch.object(inventory_plugin, "get_cache_key", return_value="test_key"):
+                with patch.object(inventory_plugin, "_read_config_data"):
+                    inventory_plugin.parse(
+                        inventory_plugin.inventory,
+                        inventory_plugin.loader,
+                        "/fake/inv.catalystcenter.yml",
+                        cache=False,
+                    )
+
+        assert "test_key" in inventory_plugin._cache
+        assert len(inventory_plugin._cache["test_key"]["devices"]) == 1
+
+    def test_cache_hit(self, inventory_plugin):
+        _set_options(inventory_plugin, cache=True)
+
+        cached_data = {
+            "devices": [_make_device(hostname="cached-host")],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._cache = {"test_key": cached_data}
+
+        with patch.object(inventory_plugin, "_fetch_all_data") as mock_fetch:
+            with patch.object(inventory_plugin, "get_cache_key", return_value="test_key"):
+                with patch.object(inventory_plugin, "_read_config_data"):
+                    inventory_plugin.parse(
+                        inventory_plugin.inventory,
+                        inventory_plugin.loader,
+                        "/fake/inv.catalystcenter.yml",
+                        cache=True,
+                    )
+
+        mock_fetch.assert_not_called()
+        assert inventory_plugin.inventory.get_host("cached-host") is not None
+
+    def test_cache_refresh(self, inventory_plugin):
+        _set_options(inventory_plugin, cache=True)
+
+        cached_data = {
+            "devices": [_make_device(hostname="old-host")],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._cache = {"test_key": cached_data}
+
+        fresh_data = {
+            "devices": [_make_device(hostname="new-host")],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+
+        with patch.object(inventory_plugin, "_fetch_all_data", return_value=fresh_data):
+            with patch.object(inventory_plugin, "get_cache_key", return_value="test_key"):
+                with patch.object(inventory_plugin, "_read_config_data"):
+                    inventory_plugin.parse(
+                        inventory_plugin.inventory,
+                        inventory_plugin.loader,
+                        "/fake/inv.catalystcenter.yml",
+                        cache=False,
+                    )
+
+        assert inventory_plugin.inventory.get_host("new-host") is not None
+
+
+# ---------------------------------------------------------------------------
+# Constructable feature tests
+# ---------------------------------------------------------------------------
+
+
+class TestConstructable:
+    def test_compose(self, inventory_plugin):
+        _set_options(
+            inventory_plugin,
+            compose={"full_name": "cc_hostname ~ '.example.com'"},
+        )
+        device = _make_device()
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        host_vars = inventory_plugin.inventory.get_host("switch-01").vars
+        assert host_vars.get("full_name") == "switch-01.example.com"
+
+    def test_keyed_groups(self, inventory_plugin):
+        _set_options(
+            inventory_plugin,
+            keyed_groups=[{"key": "cc_role", "prefix": "role"}],
+            group_by_role=False,
+        )
+        device = _make_device(role="CORE")
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        assert "role_CORE" in inventory_plugin.inventory.groups
+
+    def test_conditional_groups(self, inventory_plugin):
+        _set_options(
+            inventory_plugin,
+            groups={"reachable": "cc_reachability_status == 'Reachable'"},
+        )
+        device = _make_device(reachabilityStatus="Reachable")
+        data = {
+            "devices": [device],
+            "sites": [],
+            "device_site_map": {},
+            "tags": {},
+        }
+        inventory_plugin._populate(data)
+        assert "reachable" in inventory_plugin.inventory.groups
+        host = inventory_plugin.inventory.get_host("switch-01")
+        group_names = [
+            g.name
+            for g in inventory_plugin.inventory.groups.values()
+            if host in g.hosts
+        ]
+        assert "reachable" in group_names


### PR DESCRIPTION
## Summary

Adds a `cisco.catalystcenter.catalystcenter` dynamic inventory plugin that queries Catalyst Center for managed network devices and builds an Ansible inventory with rich grouping and host variable support.

Based on [jandiorio/ansible-dnac-inventory-plugin](https://github.com/jandiorio/ansible-dnac-inventory-plugin), modernized with current Ansible plugin patterns and the `catalystcentersdk` Python SDK that this collection already depends on.

### Key Features

- **Modern plugin architecture** — inherits from `BaseInventoryPlugin`, `Constructable`, and `Cacheable`
- **Site hierarchy grouping** — auto-creates nested Ansible groups from Catalyst Center's area/building/floor topology
- **Device role & family groups** — `role_ACCESS`, `role_CORE`, `family_Switches_and_Hubs`, etc.
- **Tag-based groups** — opt-in grouping by Catalyst Center device tags
- **Constructable support** — full `keyed_groups`, `compose`, and conditional `groups` support
- **Caching** — standard Ansible cache framework integration (jsonfile, redis, etc.)
- **Pagination** — fetch-until-empty strategy handles deployments with 500+ devices
- **Auto network OS detection** — sets `ansible_network_os` to FQCNs (`cisco.ios.ios`, `cisco.nxos.nxos`) with `ansible_connection` and become config
- **AP filtering** — Unified APs excluded by default (configurable)
- **Environment variable fallback** — reuses existing `CATALYSTCENTER_*` env vars
- **18 host variables** — all prefixed `cc_` (id, hostname, management_ip, role, family, serial_number, software_type, etc.)

### Usage

```yaml
# inventory.catalystcenter.yml
plugin: cisco.catalystcenter.catalystcenter
host: catalyst.example.com
username: admin
password: "{{ vault_cc_password }}"
validate_certs: false

keyed_groups:
  - key: cc_software_type
    prefix: os
  - key: cc_role
    prefix: role
compose:
  ansible_host: cc_management_ip
```

### Files Changed

| File | Change |
|---|---|
| `plugins/inventory/__init__.py` | New — package marker |
| `plugins/inventory/catalystcenter.py` | New — inventory plugin (695 lines) |
| `meta/runtime.yml` | Unchanged (no self-redirect needed) |
| `tests/unit/plugins/inventory/__init__.py` | New — test package marker |
| `tests/unit/plugins/inventory/test_catalystcenter.py` | New — 29 unit tests |
| `tests/integration/targets/catalystcenter_inventory/` | New — integration smoke test |
| `changelogs/fragments/inventory-plugin.yml` | New — changelog entry |

### Security Review

- Passwords handled via `no_log` option and env var fallback — never logged
- `device_filters` dict is sanitized: `offset`/`limit` keys stripped to prevent pagination override injection
- All API exceptions caught specifically (`ApiError`) — no bare `except Exception` blocks
- SSL/TLS validation enabled by default (`validate_certs: true`)
- Examples use `{{ vault_cc_password }}` — no cleartext credentials in docs
- Semgrep scan: 0 findings across 321 rules

### ⚠️ Transitive Dependency CVE Note

The `catalystcentersdk` SDK depends on `requests`, which depends on `urllib3`. The current `urllib3` 2.6.3 has two medium-severity CVEs:

| CVE | Description | Fix Version |
|---|---|---|
| **PYSEC-2026-142** | Full response decompression during `HTTPResponse.read(amt=N)` with Brotli — excessive CPU/memory consumption | urllib3 ≥ 2.7.0 |
| **PYSEC-2026-141** | Cross-origin redirects from `ProxyManager` forward sensitive headers when `assert_same_host=False` | urllib3 ≥ 2.7.0 |

These are in the `catalystcentersdk → requests → urllib3` chain. The inventory plugin itself does not use urllib3 directly. Recommend bumping urllib3 to ≥ 2.7.0 in the collection's dependency constraints or upstream in catalystcentersdk.

### Test Plan

- [x] `python3 -m py_compile` — plugin and tests compile clean
- [x] `yamllint` — no errors (warnings only, consistent with repo config)
- [x] Semgrep security scan — 0 findings
- [x] Unit tests cover: file verification, client creation, pagination, AP filtering, site hierarchy, host variables, network OS mapping, role/family/tag grouping, caching (write/hit/refresh), and Constructable features (compose/keyed_groups/conditional groups)
- [ ] Integration test with live Catalyst Center instance
- [ ] `ansible-inventory --graph` produces expected site hierarchy
- [ ] `ansible-inventory --list` shows all `cc_*` host variables