### PR TITLE
feat: add indirect node counting for AAP 2.6+ subscription compliance

### DIFF
--- a/changelogs/fragments/indirect-node-counting.yml
+++ b/changelogs/fragments/indirect-node-counting.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "Added ``extensions/audit/event_query.yml`` for AAP 2.6+ indirect node counting support."
+  - "AAP can now accurately count network devices managed indirectly through the Catalyst Center API."

--- a/extensions/audit/README.md
+++ b/extensions/audit/README.md
@@ -1,0 +1,1 @@
+This directory, and the event_query.yml file, are used by AAP (Red Hat) to capture metadata about certain module usage for indirect node counting.

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -1,0 +1,222 @@
+---
+# Indirect Node Counting Query — cisco.catalystcenter collection
+# Applies to:  Ansible Automation Platform 2.6+
+# Path:        extensions/audit/event_query.yml
+#
+# SCOPE
+# -----
+# Cisco Catalyst Center manages network devices (switches, routers, wireless
+# controllers, access points) indirectly through its REST API.  Ansible
+# connects to localhost and talks to the Catalyst Center API, which in turn
+# manages hundreds or thousands of network devices.  Without this file AAP
+# would count only the single localhost connection, not the actual managed
+# infrastructure.
+#
+# The queries below extract per-device identity from the module return data
+# so AAP can accurately count every network device managed through the
+# Catalyst Center API as an indirect managed node.
+#
+# RETURN DATA STRUCTURE
+# ---------------------
+# The cisco.catalystcenter workflow manager modules inherit from
+# CatalystCenterBase and return:
+#
+#   {
+#     "changed": bool,
+#     "diff": [{"before": {...}, "after": {...}}, ...],
+#     "response": [<message_or_dict>, ...],
+#     "warnings": [...]
+#   }
+#
+# Device identity (management IP, hostname, serial number) is available in
+# the diff entries when devices are added, updated, provisioned, or deleted.
+# The diff[].after dict typically contains keys from the Catalyst Center
+# device API: managementIpAddress, hostname, serialNumber, id, etc.
+#
+# INCLUDED MODULES
+# ----------------
+# cisco.catalystcenter.inventory_workflow_manager
+#   — Adds, updates, deletes, resyncs, and provisions network devices.
+#     This is the primary module that manages the device lifecycle.
+#     diff[].after contains the full device record from Catalyst Center.
+#
+# cisco.catalystcenter.provision_workflow_manager
+#   — Provisions devices to sites, assigns templates, and manages
+#     wired/wireless device provisioning.
+#     diff[].after contains the provisioned device details.
+#
+# cisco.catalystcenter.pnp_device_claim_to_site
+#   — Claims a Plug and Play device to a site.
+#     Return data contains the claimed device serial and hostname.
+#
+# cisco.catalystcenter.pnp_device_claim
+#   — Claims one or more Plug and Play devices.
+#     Return data contains claimed device details.
+#
+# cisco.catalystcenter.pnp_device
+#   — Manages Plug and Play device records (add/update/delete).
+#     Return data contains the PnP device record.
+#
+# EXCLUDED MODULES
+# ----------------
+# *_info modules             — Read-only queries that do not manage devices.
+#                              Including them would inflate the count with
+#                              every status check or inventory query.
+# compliance_device          — Runs compliance checks, does not manage the
+#                              device lifecycle.
+# device_replacement         — Tracks replacement workflow state; the actual
+#                              device add/remove goes through
+#                              inventory_workflow_manager.
+# assign_device_to_site      — Site assignment only; the device already
+#                              exists and is counted via
+#                              inventory_workflow_manager.
+# swim_*                     — Software image management; operates on images,
+#                              not device identity.
+# network_device_export      — Exports device data to CSV; read-only.
+# network_device_custom_prompt — Configures CLI prompts, not device lifecycle.
+#
+# NOTE: Wildcard module matching (cisco.catalystcenter.*) is intentionally
+# NOT used. It would include info/query/compliance modules and inflate the
+# count. Only modules that perform device lifecycle operations (add, update,
+# provision, claim, delete) are listed.
+
+# -----------------------------------------------------------------
+# cisco.catalystcenter.inventory_workflow_manager
+#
+# Primary device lifecycle module. Manages add/update/delete/resync
+# of network devices in Catalyst Center inventory.
+#
+# diff[].after contains device attributes from the Catalyst Center API:
+#   managementIpAddress, hostname, serialNumber, id, type, role, etc.
+#
+# Guard: managementIpAddress must be non-null — a device without a
+# management IP was not successfully committed to inventory.
+# -----------------------------------------------------------------
+cisco.catalystcenter.inventory_workflow_manager:
+  query: >-
+    .diff[]? | .after? // empty |
+    select((.managementIpAddress // null) != null) |
+    {
+      name: (.hostname // .managementIpAddress),
+      canonical_facts: {
+        management_ip: .managementIpAddress,
+        serial_number: (.serialNumber // null),
+        catalyst_center_id: (.id // null)
+      },
+      facts: {
+        device_type: (
+          if (.family // "" | test("Unified AP"; "i"))
+          then "access_point"
+          elif (.role // "" | test("ACCESS"; "i"))
+          then "network_switch"
+          elif (.role // "" | test("CORE|DISTRIBUTION"; "i"))
+          then "network_switch"
+          elif (.role // "" | test("BORDER ROUTER"; "i"))
+          then "network_router"
+          else "network_device"
+          end
+        ),
+        platform: "cisco_catalyst_center",
+        hostname: (.hostname // null),
+        role: (.role // null),
+        family: (.family // null),
+        software_type: (.softwareType // null)
+      }
+    }
+
+# -----------------------------------------------------------------
+# cisco.catalystcenter.provision_workflow_manager
+#
+# Provisions devices to sites and applies templates.
+# diff[].after contains provisioned device data.
+# -----------------------------------------------------------------
+cisco.catalystcenter.provision_workflow_manager:
+  query: >-
+    .diff[]? | .after? // empty |
+    select((.managementIpAddress // null) != null) |
+    {
+      name: (.hostname // .managementIpAddress),
+      canonical_facts: {
+        management_ip: .managementIpAddress,
+        serial_number: (.serialNumber // null),
+        catalyst_center_id: (.id // null)
+      },
+      facts: {
+        device_type: "network_device",
+        platform: "cisco_catalyst_center",
+        hostname: (.hostname // null)
+      }
+    }
+
+# -----------------------------------------------------------------
+# cisco.catalystcenter.pnp_device_claim_to_site
+#
+# Claims a PnP device to a site. The return data contains the
+# device details in the catalystcenter_response dict.
+# -----------------------------------------------------------------
+cisco.catalystcenter.pnp_device_claim_to_site:
+  query: >-
+    .catalystcenter_response? // empty |
+    .response? // empty |
+    select(type == "object") |
+    select((.serialNumber // .deviceInfo.serialNumber // null) != null) |
+    {
+      name: (.hostname // .deviceInfo.hostname // .serialNumber // .deviceInfo.serialNumber),
+      canonical_facts: {
+        serial_number: (.serialNumber // .deviceInfo.serialNumber),
+        management_ip: (.managementIpAddress // .deviceInfo.httpHeaders[0].value // null),
+        catalyst_center_id: (.id // ._id // null)
+      },
+      facts: {
+        device_type: "network_device",
+        platform: "cisco_catalyst_center"
+      }
+    }
+
+# -----------------------------------------------------------------
+# cisco.catalystcenter.pnp_device_claim
+#
+# Claims one or more PnP devices.
+# -----------------------------------------------------------------
+cisco.catalystcenter.pnp_device_claim:
+  query: >-
+    .catalystcenter_response? // empty |
+    .response? // empty |
+    select(type == "object") |
+    select((.serialNumber // .deviceInfo.serialNumber // null) != null) |
+    {
+      name: (.hostname // .deviceInfo.hostname // .serialNumber // .deviceInfo.serialNumber),
+      canonical_facts: {
+        serial_number: (.serialNumber // .deviceInfo.serialNumber),
+        management_ip: (.managementIpAddress // null),
+        catalyst_center_id: (.id // ._id // null)
+      },
+      facts: {
+        device_type: "network_device",
+        platform: "cisco_catalyst_center"
+      }
+    }
+
+# -----------------------------------------------------------------
+# cisco.catalystcenter.pnp_device
+#
+# Manages PnP device records (add/update/delete).
+# -----------------------------------------------------------------
+cisco.catalystcenter.pnp_device:
+  query: >-
+    .catalystcenter_response? // empty |
+    .response? // empty |
+    select(type == "object") |
+    select((.serialNumber // .deviceInfo.serialNumber // null) != null) |
+    {
+      name: (.hostname // .deviceInfo.hostname // .serialNumber // .deviceInfo.serialNumber),
+      canonical_facts: {
+        serial_number: (.serialNumber // .deviceInfo.serialNumber),
+        management_ip: (.managementIpAddress // null),
+        catalyst_center_id: (.id // ._id // null)
+      },
+      facts: {
+        device_type: "network_device",
+        platform: "cisco_catalyst_center"
+      }
+    }


### PR DESCRIPTION
## Summary

Adds `extensions/audit/event_query.yml` to enable Ansible Automation Platform 2.6+ to accurately count network devices managed indirectly through the Catalyst Center API.

### Problem

When Ansible manages network devices through Catalyst Center, it connects to `localhost` and talks to the Catalyst Center REST API. Without indirect node counting, AAP counts this as **1 managed node** (localhost) — regardless of whether the playbook actually managed 5 or 5,000 switches, routers, and access points behind the API.

### Solution

The `event_query.yml` file provides [jq](https://jqlang.github.io/jq/) queries that AAP uses to parse job event results and extract per-device identity from module return data. This lets AAP count every actual network device that was managed, not just the localhost connection.

### How It Works

1. AWX/AAP scrapes `extensions/audit/event_query.yml` from the installed collection
2. After a job runs, AWX processes job events through the jq queries
3. Each query extracts `name`, `canonical_facts` (unique device identity), and `facts` (device metadata)
4. Results are stored in `IndirectManagedNodeAudit` for subscription counting and analytics

### Modules Covered

| Module | What It Manages |
|---|---|
| `inventory_workflow_manager` | Network device lifecycle (add/update/delete/resync/provision) |
| `provision_workflow_manager` | Device-to-site provisioning and template assignment |
| `pnp_device_claim_to_site` | Plug and Play device claim to a site |
| `pnp_device_claim` | Plug and Play bulk device claims |
| `pnp_device` | Plug and Play device record management |

### Intentionally Excluded

- **`*_info` modules** — read-only queries; including them would inflate counts with every status check
- **`compliance_device`** — compliance checks, not device lifecycle
- **`device_replacement`** — tracks replacement state; actual add/remove uses `inventory_workflow_manager`
- **`assign_device_to_site`** — site assignment only; the device is already counted via `inventory_workflow_manager`
- **`swim_*`** — software image management, not device identity
- **Wildcard matching** (`cisco.catalystcenter.*`) — intentionally NOT used to avoid counting info/query modules

### Guard Clauses

- Devices without a valid `managementIpAddress` are excluded (incomplete inventory commit)
- Device types are classified based on role and family: `network_switch`, `network_router`, `access_point`, or generic `network_device`
- `canonical_facts` uses management IP + serial number + Catalyst Center UUID for deduplication

### Files Changed

| File | Change |
|---|---|
| `extensions/audit/event_query.yml` | New — jq queries for 5 device lifecycle modules |
| `extensions/audit/README.md` | New — explains the file's purpose |
| `changelogs/fragments/indirect-node-counting.yml` | New — changelog entry |

### Reference Implementations

- [microsoft.ad event_query.yml](https://github.com/ansible-collections/microsoft.ad/blob/main/extensions/audit/event_query.yml) — AD computer objects
- [community.vmware event_query.yml](https://github.com/ansible-collections/community.vmware/blob/main/extensions/audit/event_query.yml) — VMware guests
- [AWX PR #15802](https://github.com/ansible/awx/pull/15802) — AWX indirect host counting feature

### Validation

- [x] YAML parses correctly (`yaml.safe_load`)
- [x] All 5 jq queries validate syntactically (`jq -n`)
- [x] Tested with sample device data — correct output with canonical_facts
- [x] Guard clause verified — null managementIpAddress produces no output
- [x] AP device correctly classified as `access_point`
- [x] yamllint clean (warnings only, within repo config)
- [x] Semgrep scan: 0 findings